### PR TITLE
Support for RSVG_HANDLE_FLAG_KEEP_IMAGE_DATA

### DIFF
--- a/src/Rsvg.cc
+++ b/src/Rsvg.cc
@@ -90,7 +90,7 @@ NAN_METHOD(Rsvg::New) {
                 return ARGVAR.GetReturnValue().Set(Nan::Undefined());
             }
         } else {
-            handle = rsvg_handle_new();
+            handle = rsvg_handle_new_with_flags(RSVG_HANDLE_FLAG_KEEP_IMAGE_DATA);
         }
         // Error handling.
         if (!handle) {


### PR DESCRIPTION
This allows image data with support in the backend to directly embedded instead of being rasterized. That way SVGs with embedded JPEGs for example become much smaller.

Note: This currently only works with the `new Rsvg()` constructor.